### PR TITLE
Reverse proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ console.log("spawned cluster, kill -s SIGUSR2", process.pid, "to reload");
 // Added for the sticky listener:
 
 var balancer = sticky.createBalancer({
+  behindProxy: false,
   activeWorkers: cluster.activeWorkers,
   maxRetries: 5,
   retryDelay: 100
@@ -117,6 +118,11 @@ If there are no worker available to serve the client, retry finding one after
 The number of retries to attempt before giving up and sending a 502 Bad Gateway
 error to the client.
 
+##### `behindProxy`
+
+If you use this option, sticky-listen will read the headers and look for
+`x-forwarded-for` when reading the IP address of the client. This enables the
+balancer to work well even behind proxies such as HAProxy or nginx.
 
 ## LICENSE
 

--- a/header.txt
+++ b/header.txt
@@ -1,0 +1,16 @@
+HTTP/1.x 200 OK
+Transfer-Encoding: chunked
+Date: Sat, 28 Nov 2009 04:36:25 GMT
+Server: LiteSpeed
+Connection: close
+X-Powered-By: W3 Total Cache/0.8
+Pragma: public
+Expires: Sat, 28 Nov 2009 05:36:25 GMT
+Etag: "pub1259380237;gz"
+Cache-Control: max-age=3600, public
+Content-Type: text/html; charset=UTF-8
+Last-Modified: Sat, 28 Nov 2009 03:50:37 GMT
+X-Pingback: http://net.tutsplus.com/xmlrpc.php
+Content-Encoding: gzip
+X-Forwarded-For: 123.13.21.33
+Vary: Accept-Encoding, Cookie, User-Agent

--- a/index.js
+++ b/index.js
@@ -10,8 +10,9 @@ function createBalancer(options) {
 exports.listen = listen;
 
 function listen(server) {
-    process.on('message', function(msg, socket) {
+    process.on('message', function(msg, socket, data) {
         if (msg === 'sticky:balance' && socket != null) {
+            if (data != null) socket.push(data)
             server.emit('connection', socket);
         }
     });

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var Master = require('./lib/master')
+var Buffer = require('buffer').Buffer;
 
 exports.createBalancer = createBalancer;
 
@@ -10,9 +11,11 @@ function createBalancer(options) {
 exports.listen = listen;
 
 function listen(server) {
-    process.on('message', function(msg, socket, data) {
-        if (msg === 'sticky:balance' && socket != null) {
-            if (data != null) socket.push(data)
+    process.on('message', function(data, socket) {
+        if (data.msg === 'sticky:balance' && socket != null) {
+            if (data.payload != null) {
+                socket.push(new Buffer(data.payload, 'binary'))
+            }
             server.emit('connection', socket);
         }
     });

--- a/lib/header-parser.js
+++ b/lib/header-parser.js
@@ -59,30 +59,12 @@ function findHeader(name, data, start) {
     return -1;
 }
 
-function parse(data, fn, ctx) {
+function parse(data) {
     var start = findEq(Code.NewLine, data, 0);
     var startHeader = findHeader(forwardHeader, data, start)
-    if (startHeader === -1) return fn(null);
+    if (startHeader === -1) return null;
     var endData = findEq(Code.NewLine, data, startHeader)
-    return fn.call(ctx, data, startHeader, endData);
+    return {start: startHeader, end: endData};
 }
 
 module.exports = parse;
-
-function noop(){}
-
-if (process.env['TEST']) {
-    function test() {
-        var data = require('fs').readFileSync('header.txt');
-
-        for (var k = 0; k < 1000000; ++k) parse(data, noop);
-        console.time();
-        for (var k = 0; k < 1000000; ++k) parse(data, noop);
-        console.timeEnd();
-        parse(data, function done(data, start, end) {
-            if (!data) return console.log("No header")
-            console.log(data.slice(start+1, end).toString('utf8'))
-        })
-    }
-    test();
-}

--- a/lib/header-parser.js
+++ b/lib/header-parser.js
@@ -11,7 +11,7 @@ function cmpBufferToString(buf, start, str) {
     for (var k = 0; k < str.length; ++k) {
         var bufPos = start + k;
         if (bufPos >= buf.length) return false;
-        if (buf[bufPos] !== str.charCodeAt(k)) return false;
+        if (!eqcase(buf[bufPos], str.charCodeAt(k))) return false;
     }
     return true;
 }
@@ -31,14 +31,14 @@ function isLatinLetter(code) {
 
 function findEq(code, data, start) {
     for (var k = start; k < data.length; ++k) {
-        if (eqcase(data[k], code)) return k;
+        if (data[k] === code) return k;
     }
     return -1;
 }
 
 function findNotEq(code, data, start) {
     for (var k = start; k < data.length; ++k) {
-        if (!eqcase(data[k], code)) return k;
+        if (data[k] !== code) return k;
     }
     return -1;
 }

--- a/lib/header-parser.js
+++ b/lib/header-parser.js
@@ -8,9 +8,10 @@ var Code = {
 var forwardHeader = "x-forwarded-for";
 
 function cmpBufferToString(buf, start, str) {
-    for (var k = 0; k < str.length; ++k) {
+    var bufLen = buf.length, strLen = str.length;
+    for (var k = 0; k < strLen; ++k) {
         var bufPos = start + k;
-        if (bufPos >= buf.length) return false;
+        if (bufPos >= bufLen) return false;
         if (!eqcase(buf[bufPos], str.charCodeAt(k))) return false;
     }
     return true;
@@ -30,23 +31,24 @@ function isLatinLetter(code) {
 
 
 function findEq(code, data, start) {
-    for (var k = start; k < data.length; ++k) {
+    var dLen = data.length;
+    for (var k = start; k < dLen; ++k) {
         if (data[k] === code) return k;
     }
     return -1;
 }
 
 function findNotEq(code, data, start) {
-    for (var k = start; k < data.length; ++k) {
+    var dLen = data.length;
+    for (var k = start; k < dLen; ++k) {
         if (data[k] !== code) return k;
     }
     return -1;
 }
 
-
-
 function findHeader(name, data, start) {
-    while (start >= 0 && start < data.length) {
+    var dLen = data.length;
+    while (start >= 0 && start < dLen) {
         var headerStart = findEq(Code.NewLine, data, start) + 1;
         if (cmpBufferToString(data, headerStart, name)) {
             return headerStart + name.length + 1;
@@ -57,12 +59,12 @@ function findHeader(name, data, start) {
     return -1;
 }
 
-function parse(data, fn) {
+function parse(data, fn, ctx) {
     var start = findEq(Code.NewLine, data, 0);
     var startHeader = findHeader(forwardHeader, data, start)
     if (startHeader === -1) return fn(null);
     var endData = findEq(Code.NewLine, data, startHeader)
-    return fn(data, startHeader, endData);
+    return fn.call(ctx, data, startHeader, endData);
 }
 
 module.exports = parse;
@@ -70,14 +72,17 @@ module.exports = parse;
 function noop(){}
 
 if (process.env['TEST']) {
-    var data = require('fs').readFileSync('header.txt');
+    function test() {
+        var data = require('fs').readFileSync('header.txt');
 
-    for (var k = 0; k < 1000000; ++k) parse(data, noop);
-    console.time();
-    for (var k = 0; k < 1000000; ++k) parse(data, noop);
-    console.timeEnd();
-    parse(data, function(data, start, end) {
-        if (!data) return console.log("No header")
-        console.log(data.slice(start, end).toString('utf8'))
-    })
+        for (var k = 0; k < 1000000; ++k) parse(data, noop);
+        console.time();
+        for (var k = 0; k < 1000000; ++k) parse(data, noop);
+        console.timeEnd();
+        parse(data, function done(data, start, end) {
+            if (!data) return console.log("No header")
+            console.log(data.slice(start+1, end).toString('utf8'))
+        })
+    }
+    test();
 }

--- a/lib/header-parser.js
+++ b/lib/header-parser.js
@@ -1,0 +1,83 @@
+
+var Code = {
+    NewLine: "\n".charCodeAt(0),
+    Colon: ":".charCodeAt(0),
+    Space: " ".charCodeAt(0)
+}
+
+var forwardHeader = "x-forwarded-for";
+
+function cmpBufferToString(buf, start, str) {
+    for (var k = 0; k < str.length; ++k) {
+        var bufPos = start + k;
+        if (bufPos >= buf.length) return false;
+        if (buf[bufPos] !== str.charCodeAt(k)) return false;
+    }
+    return true;
+}
+
+function eqcase(a, b) {
+    return a === b ||
+        (Math.abs(a - b) === 32 &&
+         isLatinLetter(a) &&
+         isLatinLetter(b))
+}
+
+function isLatinLetter(code) {
+    return (code >= 97 && code <= 122) ||
+        (code >= 65 && code <= 90);
+}
+
+
+function findEq(code, data, start) {
+    for (var k = start; k < data.length; ++k) {
+        if (eqcase(data[k], code)) return k;
+    }
+    return -1;
+}
+
+function findNotEq(code, data, start) {
+    for (var k = start; k < data.length; ++k) {
+        if (!eqcase(data[k], code)) return k;
+    }
+    return -1;
+}
+
+
+
+function findHeader(name, data, start) {
+    while (start >= 0 && start < data.length) {
+        var headerStart = findEq(Code.NewLine, data, start) + 1;
+        if (cmpBufferToString(data, headerStart, name)) {
+            return headerStart + name.length + 1;
+        } else {
+            start = findEq(Code.NewLine, data, headerStart);
+        }
+    }
+    return -1;
+}
+
+function parse(data, fn) {
+    var start = findEq(Code.NewLine, data, 0);
+    var startHeader = findHeader(forwardHeader, data, start)
+    if (startHeader === -1) return fn(null);
+    var endData = findEq(Code.NewLine, data, startHeader)
+    return fn(data, startHeader, endData);
+}
+
+module.exports = parse;
+
+function noop(){}
+
+if (process.env['TEST']) {
+    var data = require('fs').readFileSync('header.txt');
+
+    for (var k = 0; k < 1000000; ++k) parse(data, noop);
+    console.time();
+    for (var k = 0; k < 1000000; ++k) parse(data, noop);
+    console.timeEnd();
+    parse(data, function(data, start, end) {
+        if (!data) return console.log("No header")
+        console.log(data.slice(start, end).toString('utf8'))
+    })
+}

--- a/lib/ip-hash.js
+++ b/lib/ip-hash.js
@@ -1,0 +1,72 @@
+var Buffer = require('buffer').Buffer
+
+var Code = {
+    Dot: '.'.charCodeAt(0),
+    Zero: '0'.charCodeAt(0)
+}
+
+function IPHasher() {
+    this.seed = (Math.random() * 0xffffffff) | 0
+}
+
+IPHasher.prototype.hashString = hashString
+IPHasher.prototype.hashBytes = hashBytes
+
+function hashBytes(ipAddr, start, len) {
+    var pos = start, currentChar = 0, octet = 0
+    var hash = this.seed
+    do {
+        if (pos === len || (currentChar = ipAddr[pos]) === Code.Dot) {
+            hash += octet
+            hash %= 2147483648
+            hash += (hash << 10)
+            hash %= 2147483648
+            hash ^= hash >> 6
+
+            octet = 0
+        }
+        else {
+            octet *= 10
+            octet += (currentChar - Code.Zero)
+        }
+    } while (pos++ < len)
+
+    hash += hash << 3
+    hash %= 2147483648
+    hash ^= hash >> 11
+    hash += hash << 15
+    hash %= 2147483648
+
+    return hash >>> 0
+}
+
+function hashString(ipAddr) {
+    var pos = 0, len = ipAddr.length, currentChar = 0, octet = 0
+    var hash = this.seed
+    do {
+        if (pos === len || (currentChar = ipAddr.charCodeAt(pos)) === Code.Dot) {
+
+            hash += octet
+            hash %= 2147483648
+            hash += (hash << 10)
+            hash %= 2147483648
+            hash ^= hash >> 6
+
+            octet = 0
+        }
+        else {
+            octet *= 10
+            octet += (currentChar - Code.Zero)
+        }
+    } while (pos++ < len)
+
+    hash += hash << 3
+    hash %= 2147483648
+    hash ^= hash >> 11
+    hash += hash << 15
+    hash %= 2147483648
+
+    return hash >>> 0
+}
+
+module.exports = IPHasher;

--- a/lib/master.js
+++ b/lib/master.js
@@ -1,10 +1,8 @@
 var util = require('util')
 var net = require('net')
 
-var Code = {
-    Dot: '.'.charCodeAt(0),
-    Zero: '0'.charCodeAt(0)
-}
+var IPHash = require('./ip-hash')
+var headerParse = require('./header-parser')
 
 module.exports = Master;
 
@@ -16,63 +14,51 @@ function Master(options) {
     net.Server.call(this, {
         pauseOnConnect: true
     }, this.balance)
-    this.seed = (Math.random() * 0xffffffff) | 0
     this.workers = options.activeWorkers;
     this.retryDelay = options.retryDelay || 150
     this.maxRetries = options.maxRetries || 5
+    this.behindProxy = options.behindProxy || false;
     if (options.strategy) {
         this.strategy = options.strategy;
     }
+    this.hasher = new IPHash()
+    this.handleData = mkDataHandler(this)
 }
 
-Master.prototype.hashString = hashString
-function hashString(ipAddr) {
-    var pos = 0, len = ipAddr.length, currentChar = 0, octet = 0
-    var hash = this.seed
-    do {
-        if (pos === len || (currentChar = ipAddr.charCodeAt(pos)) === Code.Dot) {
-
-            hash += octet
-            hash %= 2147483648
-            hash += (hash << 10)
-            hash %= 2147483648
-            hash ^= hash >> 6
-
-            octet = 0
-        }
-        else {
-            octet *= 10
-            octet += (currentChar - Code.Zero)
-        }
-    } while (pos++ < len)
-
-    hash += hash << 3
-    hash %= 2147483648
-    hash ^= hash >> 11
-    hash += hash << 15
-    hash %= 2147483648
-
-    return hash >>> 0
-}
-
-Master.prototype.strategy = function(socket, workers) {
-  var hash = this.hashString(socket.remoteAddress || '127.0.0.1');
-  var responsibleWorker = workers[hash % workers.length];
-  return responsibleWorker;
-}
-
-
-Master.prototype.balance = function balance(socket, retry) {
-  var workers = this.workers();
-  var responsibleWorker = this.strategy(socket, workers);
-  if (responsibleWorker == null) {
-      var retryCount = (retry || 0) + 1
-      if (retryCount < this.maxRetries) {
-        setTimeout(this.balance.bind(this, socket, retryCount), this.retryDelay)
-      } else {
-        socket.end('HTTP/1.0 502 Bad Gateway\n\n');
-      }
-  } else {
-    responsibleWorker.send('sticky:balance', socket);
+Master.prototype.balance = function balance(socket) {
+  if (this.behindProxy) {
+    socket.resume()
+    return socket.on('data', this.handleData)
   }
-};
+  var hash = this.hasher.hashString(socket.remoteAddress || '127.0.0.1');
+  this.delegate(hash, socket, null, 0);
+}
+
+function mkDataHandler(master) {
+  return function(data) {
+    this.pause();
+    var pos = headerParse(data), hash;
+    if (pos === null) {
+      hash = master.hasher.hashString(this.remoteAddress || '127.0.0.1')
+    } else {
+      hash = master.hasher.hashBytes(data, pos.start + 1, pos.end)
+    }
+    master.delegate(hash, this, data, 0)
+  }
+}
+
+Master.prototype.delegate = function delegate(hash, socket, data, retry) {
+  var workers = this.workers();
+  var responsibleWorker = workers[hash % workers.length]
+  if (responsibleWorker == null) {
+    var retryCount = retry + 1
+    if (retryCount < this.maxRetries) {
+      setTimeout(delegate.bind(this, hash, socket, data, retryCount), this.retryDelay)
+    } else {
+      socket.end('HTTP/1.0 502 Bad Gateway\n\n')
+    }
+  } else {
+    if (data != null) { data = data.toString('binary'); }
+    responsibleWorker.send({msg: 'sticky:balance', payload: data}, socket);
+  }
+}

--- a/lib/master.js
+++ b/lib/master.js
@@ -20,6 +20,9 @@ function Master(options) {
     this.workers = options.activeWorkers;
     this.retryDelay = options.retryDelay || 150
     this.maxRetries = options.maxRetries || 5
+    if (options.strategy) {
+        this.strategy = options.strategy;
+    }
 }
 
 Master.prototype.hashString = hashString
@@ -52,11 +55,16 @@ function hashString(ipAddr) {
     return hash >>> 0
 }
 
+Master.prototype.strategy = function(socket, workers) {
+  var hash = this.hashString(socket.remoteAddress || '127.0.0.1');
+  var responsibleWorker = workers[hash % workers.length];
+  return responsibleWorker;
+}
+
 
 Master.prototype.balance = function balance(socket, retry) {
   var workers = this.workers();
-  var hash = this.hashString(socket.remoteAddress || '127.0.0.1');
-  var responsibleWorker = workers[hash % workers.length];
+  var responsibleWorker = this.strategy(socket, workers);
   if (responsibleWorker == null) {
       var retryCount = (retry || 0) + 1
       if (retryCount < this.maxRetries) {

--- a/test/perf-unit.js
+++ b/test/perf-unit.js
@@ -1,0 +1,39 @@
+var IPHasher = require('../lib/ip-hash')
+var parse = require('../lib/header-parser')
+
+function testHasher() {
+    var h = new IPHasher();
+    var ip = '123.123.123.123';
+    var ipBuf = Buffer(ip);
+    console.log(h.hashString(ip), h.hashBytes(ipBuf, 0, ipBuf.length))
+
+    console.time('str');
+    for (var k = 0; k < 1000000; ++k) h.hashString(ip)
+    console.timeEnd('str');
+    console.time('byte')
+    for (var k = 0; k < 1000000; ++k) h.hashBytes(ipBuf, 0, ipBuf.length)
+    console.timeEnd('byte');
+}
+
+function noop(){}
+
+function testHeader() {
+    var data = require('fs').readFileSync('header.txt');
+
+    for (var k = 0; k < 1000000; ++k) parse(data);
+    console.time();
+    for (var k = 0; k < 1000000; ++k) parse(data);
+    console.timeEnd();
+    var pos = parse(data);
+    if (pos == null) {
+        console.log("No header");
+    }
+    else {
+        console.log(data.slice(pos.start+1, pos.end).toString('utf8'))
+    }
+}
+
+testHasher()
+
+testHeader();
+

--- a/test/test-basic.js
+++ b/test/test-basic.js
@@ -36,8 +36,11 @@ function test() {
             }, done).end()
         }
 
+        var sticky = null;
         function done(res) {
-            assert(res.headers['x-sticky']);
+            if (sticky == null) sticky = res.headers['x-sticky']
+            assert(res.headers['x-sticky'] == sticky);
+            sticky = res.headers['x-sticky']
             res.resume();
             if (--waiting === 0)
             process.exit(0);


### PR DESCRIPTION
Add support for proxies such as nginx or HAProxy by reading the `x-forwarded-for` header. Only works when `behindProxy` is set to `true`. Fixes #1 
