### PR TITLE
Allow usage of custom header with behindProxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ error to the client.
 ##### `behindProxy`
 
 If you use this option, sticky-listen will read the headers and look for
-`x-forwarded-for` when reading the IP address of the client. This enables the
+a header field with the value specified in `behindProxy` (if just set to true the value used is `x-forwarded-for`) when reading the IP address of the client. This enables the
 balancer to work well even behind proxies such as HAProxy or nginx.
 
 ## LICENSE

--- a/lib/header-parser.js
+++ b/lib/header-parser.js
@@ -59,9 +59,10 @@ function findHeader(name, data, start) {
     return -1;
 }
 
-function parse(data) {
+function parse(data, customHeader) {
+    customHeader = customHeader || forwardHeader;
     var start = findEq(Code.NewLine, data, 0);
-    var startHeader = findHeader(forwardHeader, data, start)
+    var startHeader = findHeader(customHeader, data, start)
     if (startHeader === -1) return null;
     var endData = findEq(Code.NewLine, data, startHeader)
     return {start: startHeader, end: endData};

--- a/lib/master.js
+++ b/lib/master.js
@@ -22,7 +22,7 @@ function Master(options) {
         this.strategy = options.strategy;
     }
     this.hasher = new IPHash()
-    this.handleData = mkDataHandler(this)
+    this.handleData = mkDataHandler(this, this.behindProxy)
 }
 
 Master.prototype.balance = function balance(socket) {
@@ -34,10 +34,10 @@ Master.prototype.balance = function balance(socket) {
   this.delegate(hash, socket, null, 0);
 }
 
-function mkDataHandler(master) {
+function mkDataHandler(master, customHeader) {
   return function(data) {
     this.pause();
-    var pos = headerParse(data), hash;
+    var pos = headerParse(data, customHeader), hash;
     if (pos === null) {
       hash = master.hasher.hashString(this.remoteAddress || '127.0.0.1')
     } else {


### PR DESCRIPTION
Hey,

as someone might use a field other than x-forwarded-for this pr allows setting a field in `behindProxy`
